### PR TITLE
FEAT: 회원가입 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "axios": "^1.9.0",
+    "cookies-next": "^5.1.0",
     "next": "15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,0 +1,56 @@
+import axios, { AxiosError, AxiosRequestConfig } from "axios";
+import { getCookie } from "cookies-next";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+export const axiosInstance = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+  withCredentials: true,
+});
+
+axiosInstance.interceptors.request.use((config) => {
+  const accessToken = localStorage.getItem("accessToken");
+  if (accessToken && config.headers) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return config;
+});
+
+axiosInstance.interceptors.request.use(
+  (response) => response,
+  async (error) => {
+    const axiosError: AxiosError = error;
+    const originalRequest = error.config;
+
+    if (
+      axiosError.response?.status === 401 &&
+      !originalRequest.retry &&
+      axiosError.message === "토큰 재발급이 필요합니다."
+    ) {
+      try {
+        const refreshToken = getCookie("refreshToken");
+        const email = localStorage.getItem("email");
+        const res = await axios.post(`${API_BASE_URL}/v1/auth/refresh`, {
+          email,
+          refreshToken,
+        });
+        const newAccessToken = res.data.accessToken;
+        localStorage.setItem("accessToken", newAccessToken);
+
+        originalRequest.headers = {
+          ...originalRequest.headers,
+          Authorization: `Bearer ${newAccessToken}`,
+        };
+
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        console.error("토큰 갱신 실패:", refreshError);
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  }
+);

--- a/src/app/auth/reset/FindPassword.tsx
+++ b/src/app/auth/reset/FindPassword.tsx
@@ -5,7 +5,7 @@ import { useResetPasswordStore } from "@/store/resetPasswordStore";
 import InputContainer from "@/components/layout/InputContainer";
 import InputField from "@/components/Input/InputField";
 import ButtonAuth from "@/components/Button/ButtonAuth";
-import ButtonNavigate from "@/components/Button/ButtonNavigate";
+import Button from "@/components/Button/ButtonNavigate";
 import FlexBox from "@/components/layout/FlexBox";
 import ToastMessage from "@/components/ToastMessage";
 

--- a/src/app/auth/signin/SignInForm.tsx
+++ b/src/app/auth/signin/SignInForm.tsx
@@ -1,24 +1,42 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { ChangeEvent, useState } from "react";
+import { useRouter } from "next/navigation";
 import InputContainer from "@/components/layout/InputContainer";
 import InputField from "@/components/Input/InputField";
 import FlexBox from "@/components/layout/FlexBox";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import Link from "next/link";
-import { useValidation } from "@/hooks/useValidation";
-import { validatePasswordConfirm } from "@/utils/validate";
+import { useAuth } from "@/hooks/useAuth";
 
 const SignInForm = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const passwordError = useValidation(
-    password,
-    validatePasswordConfirm,
-    "1234"
-  );
+  const [loginError, setLoginError] = useState("");
 
-  const handleLogin = () => {};
+  const { signIn, isSignInLoading } = useAuth();
+
+  const handleEmailChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+    setLoginError("");
+  };
+
+  const handlePasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+    setLoginError("");
+  };
+
+  const handleLogin = async () => {
+    const res = await signIn(
+      {
+        email,
+        password,
+      },
+      () => useRouter().push("/")
+    );
+    setLoginError(res.message);
+    localStorage.setItem("email", email);
+  };
 
   return (
     <FlexBox
@@ -26,32 +44,39 @@ const SignInForm = () => {
       className="gap-4 pt-12 md:w-[600px] w-[328px] mx-auto"
     >
       <h1 className="font-bold text-2xl text-[#394150] text-center">로그인</h1>
-      <form onSubmit={handleLogin} className="flex flex-col gap-8">
+      <div onSubmit={handleLogin} className="flex flex-col gap-8">
         <InputContainer label="이메일">
           <InputField
             value={email}
-            setValue={setEmail}
+            onChange={handleEmailChange}
             placeholder="이메일을 입력해주세요"
+            isError={loginError.length > 0}
           />
         </InputContainer>
         <InputContainer label="비밀번호">
           <InputField
             type="password"
             value={password}
-            setValue={setPassword}
+            onChange={handlePasswordChange}
             placeholder="비밀번호를 입력해주세요"
-            // errorMessage={passwordError}
-            // isError={!!passwordError}
+            errorMessage={loginError}
+            isError={loginError.length > 0}
           />
         </InputContainer>
-      </form>
+      </div>
       <FlexBox direction="col" className="gap-y-4 mt-8">
         <button
-          type="submit"
+          type="button"
+          onClick={handleLogin}
           className="bg-[#195BFF] md:py-4 md:px-6 py-3 px-5 rounded-xl w-full font-bold cursor-pointer"
         >
-          로그인
-          <Suspense fallback={<LoadingSpinner />}></Suspense>
+          {isSignInLoading ? (
+            <div className="flex justify-center">
+              <LoadingSpinner />
+            </div>
+          ) : (
+            "로그인"
+          )}
         </button>
         <FlexBox className="justify-center gap-x-2">
           <Link

--- a/src/app/auth/signup/steps/AccountSetUp.tsx
+++ b/src/app/auth/signup/steps/AccountSetUp.tsx
@@ -8,13 +8,19 @@ import InputField from "@/components/Input/InputField";
 import ButtonAuth from "@/components/Button/ButtonAuth";
 import { useValidation } from "@/hooks/useValidation";
 import { useSignUpStore } from "@/store/signUpStore";
+import { useAuth } from "@/hooks/useAuth";
+import { convertToFullYear } from "@/utils/convert";
 
 const AccountSetUp = () => {
   const {
+    name,
     email,
     authCode,
     password,
+    phoneNumber,
+    birth,
     passwordConfirm,
+    selectedGender,
     setEmail,
     setAuthCode,
     setPassword,
@@ -27,6 +33,14 @@ const AccountSetUp = () => {
     validatePasswordConfirm,
     passwordConfirm
   );
+
+  const {
+    signUp,
+    verifyRequest,
+    verifyConfirm,
+    isVerifyRequestLoading,
+    isVerifyConfirmLoading,
+  } = useAuth();
 
   const handleCheck = () => {
     if (
@@ -43,6 +57,36 @@ const AccountSetUp = () => {
 
   const checkAll = handleCheck();
 
+  const handleSignUp = async () => {
+    const sex = selectedGender === "남성" ? "MALE" : "FEMALE";
+    const res = await signUp(
+      {
+        email,
+        password,
+        phoneNumber,
+        username: name,
+        birthday: convertToFullYear(birth),
+        sex: sex,
+      },
+      () => setCurrentStep(4)
+    );
+    console.log(res.data);
+  };
+
+  const verifyEmail = () => {
+    verifyRequest({
+      email: email,
+      number: "",
+      reset: false,
+    });
+  };
+
+  const verifyCode = () => {
+    verifyConfirm({
+      email: email,
+      number: authCode,
+    });
+  };
   return (
     <>
       <h1 className="font-bold text-2xl text-[#394150] text-center">
@@ -61,7 +105,11 @@ const AccountSetUp = () => {
               placeholder="이메일주소를 입력해주세요"
               hasButton={true}
             />
-            <ButtonAuth text={"인증요청"} />
+            <ButtonAuth
+              text={"인증요청"}
+              onClick={verifyEmail}
+              isLoading={isVerifyRequestLoading}
+            />
           </FlexBox>
         </InputContainer>
         <InputContainer label="인증번호" isRequired={true}>
@@ -73,7 +121,12 @@ const AccountSetUp = () => {
               placeholder="인증번호를 입력해주세요"
               hasButton={true}
             />
-            <ButtonAuth text={"인증확인"} isActive={false} />
+            <ButtonAuth
+              text={"인증확인"}
+              onClick={verifyCode}
+              isActive={authCode.length > 0}
+              isLoading={isVerifyConfirmLoading}
+            />
           </FlexBox>
         </InputContainer>
         <InputContainer
@@ -108,9 +161,9 @@ const AccountSetUp = () => {
             onClick={() => setCurrentStep(2)}
           />
           <ButtonNavigate
-            text="다음"
+            text="가입"
             isActive={checkAll}
-            onClick={() => setCurrentStep(4)}
+            onClick={handleSignUp}
           />
         </div>
       </FlexBox>

--- a/src/app/auth/signup/steps/Complete.tsx
+++ b/src/app/auth/signup/steps/Complete.tsx
@@ -6,7 +6,7 @@ import FlexBox from "@/components/layout/FlexBox";
 
 const Complete = () => {
   const router = useRouter();
-  const { reset } = useSignUpStore();
+  const { name, reset } = useSignUpStore();
 
   return (
     <FlexBox
@@ -14,7 +14,7 @@ const Complete = () => {
       className="text-[#394150] md:text-[32px] text-2xl font-bold text-center h-full justify-center gap-8"
     >
       <div>
-        <p>홍길동님</p>
+        <p>{name}님</p>
         <p>회원가입이 완료되었습니다!</p>
       </div>
       <FlexBox direction="col" className="items-center">

--- a/src/app/auth/signup/steps/PersonalInfo.tsx
+++ b/src/app/auth/signup/steps/PersonalInfo.tsx
@@ -5,7 +5,7 @@ import InputField from "@/components/Input/InputField";
 import FlexBox from "@/components/layout/FlexBox";
 import ButtonNavigate from "@/components/Button/ButtonNavigate";
 import SelectOptions from "@/components/Button/SelectOptions";
-import { isValidBirth } from "@/utils/validate";
+import { isValidPhoneNumber } from "@/utils/validate";
 import { useSignUpStore } from "@/store/signUpStore";
 
 const PersonalInfo = () => {
@@ -23,26 +23,34 @@ const PersonalInfo = () => {
 
   const gender = ["남성", "여성"];
 
-  const checkPhoneNumber = () => {
-    if (typeof phoneNumber === "string") return phoneNumber !== "";
-    else return true;
-  };
+  const formatPhoneNumber = (value: string) => {
+    const numbers = value.replace(/[^\d]/g, "");
 
-  const checkBirth = () => {
-    if (typeof birth === "string") return birth !== "";
-    else return isValidBirth(birth);
+    if (!numbers) return "";
+
+    if (numbers.length <= 3) {
+      setPhoneNumber(numbers);
+      return numbers;
+    } else if (numbers.length <= 7) {
+      setPhoneNumber(`${numbers.slice(0, 3)}-${numbers.slice(3)}`);
+    } else {
+      setPhoneNumber(
+        `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(7, 11)}`
+      );
+    }
   };
 
   const handleCheck = () => {
     if (
       name.length &&
-      String(phoneNumber).length &&
-      checkBirth() &&
+      isValidPhoneNumber(phoneNumber) &&
+      birth &&
       selectedGender.length
     ) {
       return true;
     } else return false;
   };
+
   const checkAll = handleCheck();
 
   return (
@@ -59,19 +67,17 @@ const PersonalInfo = () => {
       </InputContainer>
       <InputContainer label="전화번호" isRequired={true}>
         <InputField
-          type="number"
           value={phoneNumber}
-          setValue={setPhoneNumber}
+          setValue={formatPhoneNumber}
           placeholder="전화번호를 입력해주세요"
         />
       </InputContainer>
       <InputContainer label="생년월일" isRequired={true}>
         <InputField
-          type="number"
           value={birth}
           setValue={setBirth}
           placeholder="YYMMDD 형식으로 입력해주세요"
-          maxLength={6}
+          maxLength={10}
         />
       </InputContainer>
       <FlexBox className="gap-2" direction="col">

--- a/src/app/types/auth.ts
+++ b/src/app/types/auth.ts
@@ -1,0 +1,53 @@
+interface SignUpData {
+  email: string;
+  password: string;
+  phoneNumber: string;
+  username: string;
+  birthday: string;
+  sex: "MALE" | "FEMALE";
+}
+
+/** 인증번호 요청 바디 타입 */
+interface VerifyRequest {
+  email: string;
+  number: string;
+  reset: boolean;
+}
+
+/** 인증번호 확인 바디 타입 */
+interface VerifyConfirm {
+  email: string;
+  number: string;
+}
+
+interface PasswordReset {
+  email: string;
+  password: string;
+  validatedPassword: string;
+}
+
+interface Login {
+  email: string;
+  password: string;
+}
+
+interface LoginResponse {
+  grantType: string;
+  accessToken: string;
+  memberId: number;
+  email: string;
+  nickname: string;
+  username: string;
+  agitId: string;
+  generation: string;
+  department: string;
+  job: string;
+}
+export type {
+  SignUpData,
+  VerifyRequest,
+  VerifyConfirm,
+  PasswordReset,
+  Login,
+  LoginResponse,
+};

--- a/src/components/Button/ButtonAuth.tsx
+++ b/src/components/Button/ButtonAuth.tsx
@@ -1,24 +1,21 @@
-"use client";
-
-import { useState } from "react";
 import LoadingSpinner from "../LoadingSpinner";
 
 interface ButtonAuthProps {
   text: string;
   isActive?: boolean;
+  isLoading: boolean;
   onClick?: () => void;
 }
 
-const ButtonAuth = ({ text, isActive = true, onClick }: ButtonAuthProps) => {
-  const [isLoading, setIsLoading] = useState(false);
-
+const ButtonAuth = ({
+  text,
+  isActive = true,
+  isLoading,
+  onClick,
+}: ButtonAuthProps) => {
   const handleClick = () => {
     if (onClick) {
       onClick();
-      setIsLoading(true);
-      setTimeout(() => {
-        setIsLoading(false);
-      }, 3000);
     }
   };
 

--- a/src/components/Input/InputField.tsx
+++ b/src/components/Input/InputField.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 
 type InputType = "text" | "email" | "password" | "number";
 
@@ -9,6 +9,7 @@ interface InputProps<T extends string | number> {
   value: T;
   placeholder?: string;
   setValue?: (value: T) => void;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   isPassed?: boolean;
   isError?: boolean;
   passMessage?: string;
@@ -26,6 +27,7 @@ const InputField = <T extends string | number>({
   value,
   placeholder,
   setValue,
+  onChange,
   isPassed = false,
   isError = false,
   passMessage,
@@ -67,6 +69,9 @@ const InputField = <T extends string | number>({
         placeholder={placeholder}
         maxLength={maxLength}
         onChange={(e) => {
+          if (onChange) {
+            onChange(e);
+          }
           const val = e.target.value;
           if (type === "number" && setValue) {
             setValue(val === "" ? ("" as T) : (String(val) as T));

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import axios from "axios";
+import { axiosInstance } from "@/api/axiosInstance";
+import {
+  SignUpData,
+  VerifyRequest,
+  VerifyConfirm,
+  PasswordReset,
+  Login,
+  LoginResponse,
+} from "@/app/types/auth";
+
+export const useAuth = () => {
+  const [isSignUpLoading, setIsSignUpLoading] = useState(false);
+  const [isSignInLoading, setIsSignInLoading] = useState(false);
+  const [isVerifyRequestLoading, setIsVerifyRequestLoading] = useState(false);
+  const [isVerifyConfirmLoading, setIsVerifyConfirmLoading] = useState(false);
+  //const [error, setError] = useState(null);
+
+  const signUp = async (userData: SignUpData, callback: () => void) => {
+    try {
+      setIsSignUpLoading(true);
+      const res = await axiosInstance.post(`/v1/auth/normal/signup`, userData);
+
+      if (res.status === 200) {
+        callback();
+        return res.data;
+      }
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsSignUpLoading(false);
+    }
+  };
+
+  const signIn = async (body: Login, callback: () => void) => {
+    try {
+      setIsSignInLoading(true);
+      const res = await axiosInstance.post(`/v1/auth/signin`, body);
+
+      if (res.status === 200) {
+        const result: LoginResponse = res.data;
+        localStorage.setItem("accessToken", result.accessToken);
+        callback();
+      }
+    } catch (error) {
+      console.error(error);
+      if (axios.isAxiosError(error)) {
+        return error.response?.data;
+      }
+    } finally {
+      setIsSignInLoading(false);
+    }
+  };
+
+  const login = async () => {};
+
+  const logout = async () => {};
+
+  const verifyRequest = async (body: VerifyRequest) => {
+    try {
+      setIsVerifyRequestLoading(true);
+      const res = await axiosInstance.post(
+        `/v1/normal/authenticate/email`,
+        body
+      );
+
+      if (res.status === 200) {
+        console.log(res.data);
+        return res.data;
+      }
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsVerifyRequestLoading(false);
+    }
+  };
+
+  const verifyConfirm = async (body: VerifyConfirm) => {
+    try {
+      setIsVerifyConfirmLoading(true);
+      const res = await axiosInstance.post(`/v1/normal/verify/number`, body);
+
+      if (res.status === 200) {
+        console.log(res.data);
+        return;
+      }
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsVerifyConfirmLoading(false);
+    }
+  };
+
+  const resetPassword = async (body: PasswordReset) => {};
+
+  return {
+    signUp,
+    signIn,
+    verifyRequest,
+    verifyConfirm,
+    isSignUpLoading,
+    isSignInLoading,
+    isVerifyRequestLoading,
+    isVerifyConfirmLoading,
+  };
+};

--- a/src/store/createFieldStore.ts
+++ b/src/store/createFieldStore.ts
@@ -25,7 +25,6 @@ export const createFieldStore = <T extends Record<string, any>>(
       ...dynamicSetters,
       setField: (key, value) => set((state) => ({ ...state, [key]: value })),
       reset: () => {
-        console.log(dynamicSetters);
         set(initalStates as FieldStore<T>);
       },
     };

--- a/src/store/signUpStore.ts
+++ b/src/store/signUpStore.ts
@@ -4,7 +4,6 @@ export interface SignUpStore {
   name: string;
   phoneNumber: string;
   birth: string;
-  gender: string;
   email: string;
   authCode: string;
   selectedGender: string;
@@ -19,7 +18,6 @@ const initalStates: SignUpStore = {
   name: "",
   phoneNumber: "",
   birth: "",
-  gender: "",
   email: "",
   authCode: "",
   selectedGender: "",

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,0 +1,14 @@
+function convertToFullYear(dateStr: string): string {
+  if (!/^\d{6}$/.test(dateStr)) {
+    throw new Error("Invalid format: must be 6 digits like '010101'");
+  }
+
+  const yy = dateStr.slice(0, 2);
+  const mm = dateStr.slice(2, 4);
+  const dd = dateStr.slice(4, 6);
+
+  const yearPrefix = parseInt(yy, 10) < 30 ? "20" : "19"; // 1930 기준
+  return `${yearPrefix}${yy}-${mm}-${dd}`;
+}
+
+export { convertToFullYear };

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -20,4 +20,18 @@ const validatePasswordConfirm = (password: string, confirmPassword: string) => {
   if (password !== confirmPassword) return "비밀번호가 일치하지 않습니다";
   else return "";
 };
-export { isValidEmail, isValidPassword, isValidBirth, validatePasswordConfirm };
+
+const isValidPhoneNumber = (phoneNumber: string) => {
+  // 000-0000-0000 형식 검증 (하이픈 포함)
+  const phoneRegex = /^[0-9]{3}-[0-9]{4}-[0-9]{4}$/;
+  if (!phoneRegex.test(phoneNumber)) return false;
+  else return true;
+};
+
+export {
+  isValidEmail,
+  isValidPassword,
+  isValidBirth,
+  isValidPhoneNumber,
+  validatePasswordConfirm,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,6 +780,11 @@ async-function@^1.0.0:
   resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
   integrity sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -791,6 +796,15 @@ axe-core@^4.10.0:
   version "4.10.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.3.tgz#04145965ac7894faddbac30861e5d8f11bfd14fc"
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
+
+axios@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -908,10 +922,29 @@ color@^4.2.3:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+cookie@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
+  integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
+
+cookies-next@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cookies-next/-/cookies-next-5.1.0.tgz#b6e1c7d11a4e1d38ed0586a7847cd0f403c539e1"
+  integrity sha512-9Ekne+q8hfziJtnT9c1yDUBqT0eDMGgPrfPl4bpR3xwQHLTd/8gbSf6+IEkP/pjGsDZt1TGbC6emYmFYRbIXwQ==
+  dependencies:
+    cookie "^1.0.1"
 
 cross-spawn@^7.0.6:
   version "7.0.6"
@@ -995,6 +1028,11 @@ define-properties@^1.1.3, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 detect-libc@^2.0.3:
   version "2.0.3"
@@ -1453,12 +1491,27 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
   integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
+
+form-data@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.2.tgz#35cabbdd30c3ce73deb2c42d3c8d3ed9ca51794c"
+  integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    mime-types "^2.1.12"
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -2026,6 +2079,18 @@ micromatch@^4.0.4, micromatch@^4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -2257,6 +2322,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
- hooks/useAuth.ts: useAuth 커스텀 훅 개발해서 인증 관련 로직 짬통으로 쓰도록 함
- api/axiosInstance.ts : axiosInstance 개발 (header에 인증 토큰 주입 & 만료시 리프레쉬 요청 자동화)
- utils/validate.ts, utils/convert.ts에 검증, 생년월일 형식 변환 (YYMMDD -> YYYY-MM-DD로, 백엔드에서는 이렇게 써서...)
- 그외에 자잘한 수정 (불필요한 console.log 삭제, InputField에 onChange props 추가 -> set함수와 이벤트 핸들러 별도로 처리할 수 있도록)