### PR TITLE
FEAT: 인증관련 api 연동 및 로컬 https 설정을 위한 커스텀 서버 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_ENV=development node server.js",
+    "dev": "node server.js",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "NODE_ENV=development node server.js",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,25 @@
+// server.js
+const { createServer } = require("https");
+const { parse } = require("url");
+const next = require("next");
+const fs = require("fs");
+const path = require("path");
+
+const port = 3000;
+const dev = process.env.NODE_ENV !== "production";
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+const httpsOptions = {
+  key: fs.readFileSync("./key.pem"),
+  cert: fs.readFileSync("./cert.pem"),
+};
+
+app.prepare().then(() => {
+  createServer(httpsOptions, (req, res) => {
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
+  }).listen(port, () => {
+    console.log(`> Server started on https://localhost:${port}`);
+  });
+});

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@ const { createServer } = require("https");
 const { parse } = require("url");
 const next = require("next");
 const fs = require("fs");
-const path = require("path");
 
 const port = 3000;
 const dev = process.env.NODE_ENV !== "production";

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosRequestConfig } from "axios";
+import axios, { AxiosError } from "axios";
 import { getCookie } from "cookies-next";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -32,6 +32,7 @@ axiosInstance.interceptors.request.use(
     ) {
       try {
         const refreshToken = getCookie("refreshToken");
+        console.log(refreshToken);
         const email = localStorage.getItem("email");
         const res = await axios.post(`${API_BASE_URL}/v1/auth/refresh`, {
           email,

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -32,7 +32,6 @@ axiosInstance.interceptors.request.use(
     ) {
       try {
         const refreshToken = getCookie("refreshToken");
-        console.log(refreshToken);
         const email = localStorage.getItem("email");
         const res = await axios.post(`${API_BASE_URL}/v1/auth/refresh`, {
           email,

--- a/src/app/auth/reset/FindPassword.tsx
+++ b/src/app/auth/reset/FindPassword.tsx
@@ -5,7 +5,7 @@ import { useResetPasswordStore } from "@/store/resetPasswordStore";
 import InputContainer from "@/components/layout/InputContainer";
 import InputField from "@/components/Input/InputField";
 import ButtonAuth from "@/components/Button/ButtonAuth";
-import Button from "@/components/Button/ButtonNavigate";
+import ButtonNavigate from "@/components/Button/ButtonNavigate";
 import FlexBox from "@/components/layout/FlexBox";
 import ToastMessage from "@/components/ToastMessage";
 
@@ -63,25 +63,31 @@ const FindPassword = () => {
             setValue={setEmail}
             placeholder="이메일 주소를 입력해주세요"
             hasButton={true}
-            isCounting={isAuthRequested}
           />
-          <ButtonAuth text="인증요청" onClick={hanldeAuthRequest} />
+          <ButtonAuth
+            text="인증요청"
+            onClick={hanldeAuthRequest}
+            isLoading={false}
+          />
         </FlexBox>
       </InputContainer>
       <InputContainer label="인증번호" isRequired={true}>
         <FlexBox className="items-center justify-between">
           <InputField
+            type="number"
             value={authCode}
             setValue={setAuthCode}
             placeholder="인증번호를 입력해주세요"
             hasButton={true}
-            isPassed={true}
-            passMessage="* 인증번호가 확인되었습니다."
+            isCounting={isAuthRequested}
+            // isPassed={true}
+            // passMessage="* 인증번호가 확인되었습니다."
           />
           <ButtonAuth
             text="인증확인"
             isActive={authCode.length > 0}
             onClick={handleAuthConfirm}
+            isLoading={false}
           />
         </FlexBox>
       </InputContainer>

--- a/src/app/auth/reset/FindPassword.tsx
+++ b/src/app/auth/reset/FindPassword.tsx
@@ -8,6 +8,7 @@ import ButtonAuth from "@/components/Button/ButtonAuth";
 import ButtonNavigate from "@/components/Button/ButtonNavigate";
 import FlexBox from "@/components/layout/FlexBox";
 import ToastMessage from "@/components/ToastMessage";
+import { useAuth } from "@/hooks/useAuth";
 
 const FindPassword = () => {
   const {
@@ -24,17 +25,40 @@ const FindPassword = () => {
 
   const [isAuthRequested, setIsAuthRequested] = useState(false);
   const [isToastOpen, setIsToastOpen] = useState(false);
+  const [isPassed, setIsPassed] = useState(false);
 
-  const hanldeAuthRequest = () => {
-    setIsToastOpen(true);
-  };
-
-  const handleAuthConfirm = () => {
-    setIsAuthRequested(true);
-  };
+  const {
+    verifyEmail,
+    verifyConfirm,
+    isVerifyEmailLoading,
+    isVerifyConfirmLoading,
+  } = useAuth();
 
   const isActive =
-    name !== "" && birth !== "" && email !== "" && authCode !== "";
+    name !== "" && birth !== "" && email !== "" && authCode !== "" && isPassed;
+
+  const handleVerifyEmail = () => {
+    verifyEmail(
+      {
+        email: email,
+        number: authCode,
+      },
+      true
+    );
+  };
+
+  const handleVerifyConfirm = async () => {
+    const res = await verifyConfirm(
+      {
+        email: email,
+        number: authCode,
+      },
+      true
+    );
+    if (res === 200) {
+      setIsPassed(true);
+    }
+  };
 
   return (
     <FlexBox className="pt-4 gap-8" direction="col">
@@ -66,8 +90,8 @@ const FindPassword = () => {
           />
           <ButtonAuth
             text="인증요청"
-            onClick={hanldeAuthRequest}
-            isLoading={false}
+            onClick={handleVerifyEmail}
+            isLoading={isVerifyEmailLoading}
           />
         </FlexBox>
       </InputContainer>
@@ -80,14 +104,14 @@ const FindPassword = () => {
             placeholder="인증번호를 입력해주세요"
             hasButton={true}
             isCounting={isAuthRequested}
-            // isPassed={true}
-            // passMessage="* 인증번호가 확인되었습니다."
+            isPassed={isPassed}
+            passMessage="* 인증번호가 확인되었습니다."
           />
           <ButtonAuth
             text="인증확인"
             isActive={authCode.length > 0}
-            onClick={handleAuthConfirm}
-            isLoading={false}
+            onClick={handleVerifyConfirm}
+            isLoading={isVerifyConfirmLoading}
           />
         </FlexBox>
       </InputContainer>

--- a/src/app/auth/reset/ResetPassword.tsx
+++ b/src/app/auth/reset/ResetPassword.tsx
@@ -7,6 +7,9 @@ import ButtonNavigateLarge from "@/components/Button/ButtonNavigateLarge";
 import FlexBox from "@/components/layout/FlexBox";
 import { useValidation } from "@/hooks/useValidation";
 import { isValidPassword, validatePasswordConfirm } from "@/utils/validate";
+import { useAuth } from "@/hooks/useAuth";
+import { useResetPasswordStore } from "@/store/resetPasswordStore";
+import ToastMessage from "@/components/ToastMessage";
 
 const ResetPassword = () => {
   const [newPassword, setNewPassword] = useState("");
@@ -20,11 +23,26 @@ const ResetPassword = () => {
     passwordConfirm
   );
 
-  const handlePasswordUpdate = () => {
-    setIsToastOpen(!isToastOpen);
-  };
+  const { email } = useResetPasswordStore();
 
   const isActive = newPassword !== "" && passwordConfirm !== "";
+
+  const { resetPassword, isResetPasswordLoading } = useAuth();
+
+  const handleUpdatePassword = async () => {
+    if (newPassword === passwordConfirm) {
+      const res = await resetPassword({
+        email: email,
+        password: newPassword,
+        validatedPassword: passwordConfirm,
+      });
+      if (res.message) {
+        setIsToastOpen(true);
+      }
+      setNewPassword("");
+      setPasswordConfirm("");
+    }
+  };
 
   return (
     <FlexBox className="pt-4 gap-8" direction="col">
@@ -52,11 +70,17 @@ const ResetPassword = () => {
           isError={!!passwordConfirmError}
         ></InputField>
       </InputContainer>
+      <ToastMessage
+        message={"비밀번호가 재설정되었습니다."}
+        isOpen={isToastOpen}
+        setIsOpen={setIsToastOpen}
+      />
       <div className="flex flex-col-reverse md:flex-row font-bold md:justify-end py-8 gap-1">
         <ButtonNavigateLarge
           text="비밀번호 재설정"
           isActive={isActive}
-          onClick={handlePasswordUpdate}
+          onClick={handleUpdatePassword}
+          isLoading={isResetPasswordLoading}
         />
       </div>
     </FlexBox>

--- a/src/app/auth/signin/SignInForm.tsx
+++ b/src/app/auth/signin/SignInForm.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
 
 const SignInForm = () => {
+  const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loginError, setLoginError] = useState("");
@@ -27,14 +28,15 @@ const SignInForm = () => {
   };
 
   const handleLogin = async () => {
-    const res = await signIn(
-      {
-        email,
-        password,
-      },
-      () => useRouter().push("/")
-    );
-    setLoginError(res.message);
+    const res = await signIn({
+      email,
+      password,
+    });
+    if (res === 200) {
+      router.push("/");
+    } else if (res && res.message) {
+      setLoginError(res.message);
+    }
     localStorage.setItem("email", email);
   };
 
@@ -87,7 +89,7 @@ const SignInForm = () => {
           </Link>
           <div className="w-[1.2px] h-5 bg-[#E5E7EB] mx-2" />
           <Link
-            href="/"
+            href="/auth/reset"
             className="text-[#394150] opacity-60 text-sm md:text-md"
           >
             비밀번호 찾기

--- a/src/app/auth/signup/steps/AccountSetUp.tsx
+++ b/src/app/auth/signup/steps/AccountSetUp.tsx
@@ -36,9 +36,9 @@ const AccountSetUp = () => {
 
   const {
     signUp,
-    verifyRequest,
+    verifyEmail,
     verifyConfirm,
-    isVerifyRequestLoading,
+    isVerifyEmailLoading,
     isVerifyConfirmLoading,
   } = useAuth();
 
@@ -59,33 +59,34 @@ const AccountSetUp = () => {
 
   const handleSignUp = async () => {
     const sex = selectedGender === "남성" ? "MALE" : "FEMALE";
-    const res = await signUp(
-      {
-        email,
-        password,
-        phoneNumber,
-        username: name,
-        birthday: convertToFullYear(birth),
-        sex: sex,
-      },
-      () => setCurrentStep(4)
-    );
-    console.log(res.data);
+    const res = await signUp({
+      email,
+      password,
+      phoneNumber,
+      username: name,
+      birthday: convertToFullYear(birth),
+      sex: sex,
+    });
   };
 
-  const verifyEmail = () => {
-    verifyRequest({
-      email: email,
-      number: "",
-      reset: false,
-    });
+  const handleVerifyEmail = () => {
+    verifyEmail(
+      {
+        email: email,
+        number: "",
+      },
+      false
+    );
   };
 
   const verifyCode = () => {
-    verifyConfirm({
-      email: email,
-      number: authCode,
-    });
+    verifyConfirm(
+      {
+        email: email,
+        number: authCode,
+      },
+      false
+    );
   };
   return (
     <>
@@ -107,8 +108,8 @@ const AccountSetUp = () => {
             />
             <ButtonAuth
               text={"인증요청"}
-              onClick={verifyEmail}
-              isLoading={isVerifyRequestLoading}
+              onClick={handleVerifyEmail}
+              isLoading={isVerifyEmailLoading}
             />
           </FlexBox>
         </InputContainer>

--- a/src/app/types/auth.ts
+++ b/src/app/types/auth.ts
@@ -8,10 +8,9 @@ interface SignUpData {
 }
 
 /** 인증번호 요청 바디 타입 */
-interface VerifyRequest {
+interface VerifyEmail {
   email: string;
   number: string;
-  reset: boolean;
 }
 
 /** 인증번호 확인 바디 타입 */
@@ -45,7 +44,7 @@ interface LoginResponse {
 }
 export type {
   SignUpData,
-  VerifyRequest,
+  VerifyEmail,
   VerifyConfirm,
   PasswordReset,
   Login,

--- a/src/components/Button/ButtonNavigate.tsx
+++ b/src/components/Button/ButtonNavigate.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import LoadingSpinner from "../LoadingSpinner";
+
 export interface ButtonNavigateProps {
   text: string;
   isActive?: boolean;
   isDisabled?: boolean;
   onClick?: () => void;
   hasBackGround?: boolean;
+  isLoading?: boolean;
   className?: string;
 }
 
@@ -14,6 +17,7 @@ const ButtonNavigate = ({
   isActive = true,
   onClick,
   hasBackGround = true,
+  isLoading = false,
   className,
 }: ButtonNavigateProps) => {
   return (
@@ -28,7 +32,13 @@ const ButtonNavigate = ({
       onClick={onClick}
       disabled={!isActive}
     >
-      {text}
+      {isLoading ? (
+        <div className="flex justify-center">
+          <LoadingSpinner />
+        </div>
+      ) : (
+        text
+      )}
     </button>
   );
 };

--- a/src/components/Button/ButtonNavigateLarge.tsx
+++ b/src/components/Button/ButtonNavigateLarge.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import LoadingSpinner from "../LoadingSpinner";
 import { ButtonNavigateProps } from "./ButtonNavigate";
 
 const ButtonNavigateLarge = ({
@@ -7,6 +8,7 @@ const ButtonNavigateLarge = ({
   isActive = true,
   onClick,
   hasBackGround = true,
+  isLoading = false,
   className,
 }: ButtonNavigateProps) => {
   return (
@@ -21,7 +23,13 @@ const ButtonNavigateLarge = ({
       onClick={onClick}
       disabled={!isActive}
     >
-      {text}
+      {isLoading ? (
+        <div className="flex justify-center">
+          <LoadingSpinner />
+        </div>
+      ) : (
+        text
+      )}
     </button>
   );
 };

--- a/src/components/Input/InputField.tsx
+++ b/src/components/Input/InputField.tsx
@@ -93,7 +93,7 @@ const InputField = <T extends string | number>({
           {errorMessage}
         </p>
       )}
-      {passMessage && (
+      {isPassed && passMessage && (
         <p className="absolute bottom-[-24px] text-sm text-green-600">
           {passMessage}
         </p>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,105 +1,124 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import Link from 'next/link';
-import Icons from '@/components/Icons';
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import Icons from "@/components/Icons";
+import { useAuth } from "@/hooks/useAuth";
+import { useLoginStore } from "@/store/loginStore";
 
 const Header = () => {
-    const [isMobileOpen, setIsMobileOpen] = useState(false);
-    const [isLogin, setIsLogin] = useState(true);
-    const redirectionList = ['RECRUIT', 'FAQ', ...(isLogin ? ['MYPAGE'] : [])];
+  const router = useRouter();
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
+  const { isLogin } = useLoginStore();
+  const { signout } = useAuth();
 
-    return (
-        <header
-            className="fixed top-0 w-full z-50
+  const redirectionList = ["RECRUIT", "FAQ", ...(isLogin ? ["MYPAGE"] : [])];
+
+  const handleLoginAndOut = () => {
+    if (isLogin) {
+      signout();
+      router.push("/");
+    } else {
+      router.push("/auth/signin");
+    }
+  };
+
+  return (
+    <header
+      className="fixed top-0 w-full z-50
               bg-gradient-to-b from-[#121212] from-30% to-transparent"
+    >
+      <div className="hidden md:flex items-center justify-between py-7 px-16 z-50">
+        <Link href="/" className="z-50">
+          <Icons name="logo" width={101} height={45} />
+        </Link>
+        <nav>
+          <ul className="flex gap-x-12 font-bold items-center">
+            {redirectionList.map((item, index) => (
+              <li key={index}>
+                <Link href={`/${item.toLowerCase()}`} className="relative z-50">
+                  {item}
+                </Link>
+              </li>
+            ))}
+            <li>
+              <button
+                className="relative z-50 bg-gradient-to-br from-[#1A5BFF] to-[#60AFFF] py-2 px-4 rounded-[10px] cursor-pointer"
+                onClick={handleLoginAndOut}
+              >
+                {isLogin ? "LOGOUT" : "LOGIN"}
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        className={`fixed w-full flex md:hidden items-center justify-between p-7 z-50 ${
+          isMobileOpen
+            ? "bg-transparent"
+            : "bg-gradient-to-b from-black from-30% to-transparent"
+        }`}
+      >
+        <Link href="/">
+          <Icons name="logo" width={101} height={45} />
+        </Link>
+        <button
+          onClick={() => setIsMobileOpen(!isMobileOpen)}
+          className="cursor-pointer w-8 flex flex-col items-center"
         >
-            <div className="hidden md:flex items-center justify-between py-7 px-16 z-50">
-                <Link href="/" className="z-50">
-                    <Icons name="logo" width={101} height={45} />
-                </Link>
-                <nav>
-                    <ul className="flex gap-x-12 font-bold">
-                        {redirectionList.map((item, index) => (
-                            <li key={index}>
-                                <Link href={`/${item.toLowerCase()}`} className="relative z-50">
-                                    {item}
-                                </Link>
-                            </li>
-                        ))}
-                        <li>
-                            <Link
-                                href="/auth/signup"
-                                className="relative z-50 bg-gradient-to-br from-[#1A5BFF] to-[#60AFFF] py-2.5 px-4 rounded-[10px]"
-                            >
-                                {isLogin ? 'LOGOUT' : 'LOGIN'}
-                            </Link>
-                        </li>
-                    </ul>
-                </nav>
-            </div>
-            <div
-                className={`fixed w-full flex md:hidden items-center justify-between p-7 z-50 ${
-                    isMobileOpen ? 'bg-transparent' : 'bg-gradient-to-b from-black from-30% to-transparent'
-                }`}
+          <div className="space-y-1.5 transition-all duration-300 ease-in-out">
+            <span
+              className={`block h-0.5 bg-white rounded transform transition-all duration-300 ${
+                isMobileOpen ? "rotate-45 translate-y-2" : ""
+              }`}
+            ></span>
+            <span
+              className={`block h-0.5 bg-white rounded transition-opacity duration-300 ${
+                isMobileOpen ? "opacity-0" : ""
+              }`}
+            ></span>
+            <span
+              className={`block w-5 h-0.5 bg-white rounded transform transition-all duration-300 ${
+                isMobileOpen ? "-rotate-45 -translate-y-2" : ""
+              }`}
+            ></span>
+          </div>
+        </button>
+      </div>
+      <>
+        {isMobileOpen && (
+          <div
+            className="fixed inset-0 bg-[#121212]/0 z-10"
+            onClick={() => {
+              setIsMobileOpen(!isMobileOpen);
+            }}
+          />
+        )}
+        <ul
+          className={`fixed top-0 w-full bg-[#121212] pt-20 pl-7 pb-5 z-30 transition-all duration-500 ease-in-out transform font-bold ${
+            isMobileOpen
+              ? "translate-y-0 opacity-100"
+              : "-translate-y-full opacity-0"
+          }`}
+        >
+          {redirectionList.map((item, index) => (
+            <li key={index} className="py-3 ">
+              <Link href={`/${item.toLowerCase()}`}>{item}</Link>
+            </li>
+          ))}
+          <li className="py-6">
+            <button
+              className="relative z-50 bg-gradient-to-br from-[#1A5BFF] to-[#60AFFF] py-2 px-4 rounded-[10px]"
+              onClick={handleLoginAndOut}
             >
-                <Link href="/">
-                    <Icons name="logo" width={101} height={45} />
-                </Link>
-                <button
-                    onClick={() => setIsMobileOpen(!isMobileOpen)}
-                    className="cursor-pointer w-8 flex flex-col items-center"
-                >
-                    <div className="space-y-1.5 transition-all duration-300 ease-in-out">
-                        <span
-                            className={`block h-0.5 bg-white rounded transform transition-all duration-300 ${
-                                isMobileOpen ? 'rotate-45 translate-y-2' : ''
-                            }`}
-                        ></span>
-                        <span
-                            className={`block h-0.5 bg-white rounded transition-opacity duration-300 ${
-                                isMobileOpen ? 'opacity-0' : ''
-                            }`}
-                        ></span>
-                        <span
-                            className={`block w-5 h-0.5 bg-white rounded transform transition-all duration-300 ${
-                                isMobileOpen ? '-rotate-45 -translate-y-2' : ''
-                            }`}
-                        ></span>
-                    </div>
-                </button>
-            </div>
-            <>
-                {isMobileOpen && (
-                    <div
-                        className="fixed inset-0 bg-[#121212]/0 z-10"
-                        onClick={() => {
-                            setIsMobileOpen(!isMobileOpen);
-                        }}
-                    />
-                )}
-                <ul
-                    className={`fixed top-0 w-full bg-[#121212] pt-20 pl-7 pb-5 z-30 transition-all duration-500 ease-in-out transform font-bold ${
-                        isMobileOpen ? 'translate-y-0 opacity-100' : '-translate-y-full opacity-0'
-                    }`}
-                >
-                    {redirectionList.map((item, index) => (
-                        <li key={index} className="py-3 ">
-                            <Link href={`/${item.toLowerCase()}`}>{item}</Link>
-                        </li>
-                    ))}
-                    <li className="py-6">
-                        <Link
-                            href="/auth/signup"
-                            className="bg-gradient-to-br from-[#1A5BFF] to-[#60AFFF] py-2.5 px-4 rounded-[10px]"
-                        >
-                            {isLogin ? 'LOGOUT' : 'LOGIN'}
-                        </Link>
-                    </li>
-                </ul>
-            </>
-        </header>
-    );
+              {isLogin ? "LOGOUT" : "LOGIN"}
+            </button>
+          </li>
+        </ul>
+      </>
+    </header>
+  );
 };
 
 export default Header;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 import { axiosInstance } from "@/api/axiosInstance";
 import {
   SignUpData,
-  VerifyRequest,
+  VerifyEmail,
   VerifyConfirm,
   PasswordReset,
   Login,
@@ -15,9 +15,9 @@ export const useAuth = () => {
   const { setIsLogin } = useLoginStore();
   const [isSignUpLoading, setIsSignUpLoading] = useState(false);
   const [isSignInLoading, setIsSignInLoading] = useState(false);
-  const [isVerifyRequestLoading, setIsVerifyRequestLoading] = useState(false);
+  const [isVerifyEmailLoading, setIsVerifyEmailLoading] = useState(false);
   const [isVerifyConfirmLoading, setIsVerifyConfirmLoading] = useState(false);
-  //const [error, setError] = useState(null);
+  const [isResetPasswordLoading, setIsResetPasswordLoading] = useState(false);
 
   const signUp = async (userData: SignUpData) => {
     try {
@@ -69,33 +69,34 @@ export const useAuth = () => {
     }
   };
 
-  const verifyRequest = async (body: VerifyRequest) => {
+  const verifyEmail = async (body: VerifyEmail, reset: boolean) => {
     try {
-      setIsVerifyRequestLoading(true);
+      setIsVerifyEmailLoading(true);
       const res = await axiosInstance.post(
-        `/v1/normal/authenticate/email`,
+        `/v1/normal/authenticate/email?reset=${reset}`,
         body
       );
 
       if (res.status === 200) {
-        console.log(res.data);
         return res.data;
       }
     } catch (error) {
       console.error(error);
     } finally {
-      setIsVerifyRequestLoading(false);
+      setIsVerifyEmailLoading(false);
     }
   };
 
-  const verifyConfirm = async (body: VerifyConfirm) => {
+  const verifyConfirm = async (body: VerifyConfirm, reset: boolean) => {
     try {
       setIsVerifyConfirmLoading(true);
-      const res = await axiosInstance.post(`/v1/normal/verify/number`, body);
+      const res = await axiosInstance.post(
+        `/v1/normal/verify/number?reset=${reset}`,
+        body
+      );
 
       if (res.status === 200) {
-        console.log(res.data);
-        return;
+        return res.status;
       }
     } catch (error) {
       console.error(error);
@@ -104,17 +105,32 @@ export const useAuth = () => {
     }
   };
 
-  const resetPassword = async (body: PasswordReset) => {};
+  const resetPassword = async (body: PasswordReset) => {
+    try {
+      setIsResetPasswordLoading(true);
+      const res = await axiosInstance.post(`/v1/normal/password/change`, body);
+
+      if (res.status === 200) {
+        return res.data;
+      }
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsResetPasswordLoading(false);
+    }
+  };
 
   return {
     signUp,
     signIn,
-    verifyRequest,
+    verifyEmail,
     verifyConfirm,
     signout,
+    resetPassword,
     isSignUpLoading,
     isSignInLoading,
-    isVerifyRequestLoading,
+    isVerifyEmailLoading,
     isVerifyConfirmLoading,
+    isResetPasswordLoading,
   };
 };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -9,21 +9,22 @@ import {
   Login,
   LoginResponse,
 } from "@/app/types/auth";
+import { useLoginStore } from "@/store/loginStore";
 
 export const useAuth = () => {
+  const { setIsLogin } = useLoginStore();
   const [isSignUpLoading, setIsSignUpLoading] = useState(false);
   const [isSignInLoading, setIsSignInLoading] = useState(false);
   const [isVerifyRequestLoading, setIsVerifyRequestLoading] = useState(false);
   const [isVerifyConfirmLoading, setIsVerifyConfirmLoading] = useState(false);
   //const [error, setError] = useState(null);
 
-  const signUp = async (userData: SignUpData, callback: () => void) => {
+  const signUp = async (userData: SignUpData) => {
     try {
       setIsSignUpLoading(true);
       const res = await axiosInstance.post(`/v1/auth/normal/signup`, userData);
 
       if (res.status === 200) {
-        callback();
         return res.data;
       }
     } catch (error) {
@@ -33,19 +34,21 @@ export const useAuth = () => {
     }
   };
 
-  const signIn = async (body: Login, callback: () => void) => {
+  const signIn = async (body: Login) => {
     try {
       setIsSignInLoading(true);
       const res = await axiosInstance.post(`/v1/auth/signin`, body);
 
       if (res.status === 200) {
-        const result: LoginResponse = res.data;
+        const data = res.data;
+        const result: LoginResponse = data.result;
         localStorage.setItem("accessToken", result.accessToken);
-        callback();
+        setIsLogin(true);
+        return res.status;
       }
     } catch (error) {
-      console.error(error);
       if (axios.isAxiosError(error)) {
+        console.error(error.response);
         return error.response?.data;
       }
     } finally {
@@ -53,9 +56,18 @@ export const useAuth = () => {
     }
   };
 
-  const login = async () => {};
+  const signout = async () => {
+    try {
+      const res = await axiosInstance.get(`/v1/auth/signout`);
 
-  const logout = async () => {};
+      if (res.status === 200) {
+        setIsLogin(false);
+        console.log(res.data);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
   const verifyRequest = async (body: VerifyRequest) => {
     try {
@@ -99,6 +111,7 @@ export const useAuth = () => {
     signIn,
     verifyRequest,
     verifyConfirm,
+    signout,
     isSignUpLoading,
     isSignInLoading,
     isVerifyRequestLoading,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/** 비로그인시 로그인 페이지로 리디렉션 해줘야할 경로들 */
+export const config = {
+  matcher: ["/recruit", "/mypage", "/auth/reset", "/welcome"],
+};
+export default function middleware(request: NextRequest) {
+  const refreshToken = request.cookies.get("refreshToken");
+
+  // if (!refreshToken) {
+  //   return NextResponse.redirect(new URL("/auth/signin", request.url));
+  // }
+
+  return NextResponse.next();
+}

--- a/src/store/loginStore.ts
+++ b/src/store/loginStore.ts
@@ -1,0 +1,12 @@
+import { createFieldStore } from "./createFieldStore";
+
+interface LoginState {
+  isLogin: boolean;
+}
+
+const initState = {
+  isLogin: false,
+};
+
+const useLoginStore = createFieldStore(initState);
+export { useLoginStore };


### PR DESCRIPTION
로컬에서 https로 띄우기 위해 커스텀 서버 코드를 추가.
"dev": "next dev --turbopack",
->  "dev": "NODE_ENV=development node server.js"

앞으로 api 연동하며 작업할때 로컬 띄울려면 SSL/TLS 인증서를 직접 적용해서 해야함.
key.pem, cert.pem 다운받아서 루트 디렉토리에 넣어주면 됨

https://andrew0314.tistory.com/96 
-> localhost https로 띄우는법 참고

- 현재 회원가입, 비밀번호 재설정, 로그인, 로그아웃 api 연동 작업 완료

남은 작업
1. 새로고침시 리프레시 토큰이 사리지는 문제 해결
2. 1번 문제가 해결되면 로그인 여부에 따라 적절히 리디렉션 해주는 미들웨어 개발
3. 최종 합격 페이지 마무리 작업
